### PR TITLE
Added a lot of new support

### DIFF
--- a/README
+++ b/README
@@ -25,10 +25,19 @@ Installation:
 
 Usage:
 
-    sshpot [-h] [-p <port>]
-        -h  --help          Display this usage information.
-        -p  --port <port>   Port to listen on; defaults to 22.
+    sshpot [-h]
 
+        -h  --help             Display this usage information.
+        -l  --listen {addr}    Listen address; defaults to 0.0.0.0.
+        -p  --port <port>      Port to listen on; defaults to 22.
+        -r  --rsa <file>       RSA Key file; defaults to ./sshpot.rsa.key.
+        -L  --logfile <file>   Output log file; defaults to sshpot_auth.log
+        -s  --syslog           Log output to syslog.
+        -u  --user <username>  Username to drop privs to; defaults to 'nobody'.
+        -g  --group <group>    Group to drop privs to; defaults to 'nogroup'.
+        -d  --daemon           Become a daemon.
+        -t  --delay <#>        Seconds to delay between auth attempts; default 2s.
+        -c  --chroot <dir>     Run in a chroot environment.
 
 Dependencies:
 

--- a/README
+++ b/README
@@ -38,6 +38,7 @@ Usage:
         -d  --daemon           Become a daemon.
         -t  --delay <#>        Seconds to delay between auth attempts; default 2s.
         -c  --chroot <dir>     Run in a chroot environment.
+        -b  --banner <banner>  SSH Banner; defaults to 'OpenSSH_6.7p1 Debian-5+deb8u3'.
 
 Dependencies:
 

--- a/auth.c
+++ b/auth.c
@@ -5,11 +5,16 @@
 #include <libssh/server.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <stdbool.h>
+#include <syslog.h>
+#include <pwd.h>
+#include <grp.h>
 
-
+#include <unistd.h>
 
 /* Stores the current UTC time. Returns 0 on error. */
 static int get_utc(struct connection *c) {
@@ -35,11 +40,11 @@ static int *get_client_ip(struct connection *c) {
 
 /* Write interesting information about a connection attempt to  LOGFILE. 
  * Returns -1 on error. */
-static int log_attempt(struct connection *c) {
+static int log_attempt(struct connection *c, char *logfile, bool syslog_bool) {
     FILE *f;
     int r;
 
-    if ((f = fopen(LOGFILE, "a+")) == NULL) {
+    if ((f = fopen(logfile, "a+")) == NULL) {
         fprintf(stderr, "Unable to open %s\n", LOGFILE);
         return -1;
     }
@@ -57,15 +62,22 @@ static int log_attempt(struct connection *c) {
     c->user = ssh_message_auth_user(c->message);
     c->pass = ssh_message_auth_password(c->message);
 
+    if ( syslog_bool ) {
+	openlog("sshpot",SYSLOG_PRIORITY, SYSLOG_FACILITY);
+	syslog(LOG_PID, "Login attempt from %s,  username %s, password %s", c->client_ip, c->user, c->pass); 	
+	closelog(); 
+	}
+
     if (DEBUG) { printf("%s %s %s %s\n", c->con_time, c->client_ip, c->user, c->pass); }
     r = fprintf(f, "%s %s %s %s\n", c->con_time, c->client_ip, c->user, c->pass);
     fclose(f);
+
     return r;
 }
 
 
 /* Logs password auth attempts. Always replies with SSH_MESSAGE_USERAUTH_FAILURE. */
-int handle_auth(ssh_session session) {
+int handle_auth(ssh_session session, char *logfile, bool syslog_bool, int delay) {
     struct connection con;
     con.session = session;
 
@@ -85,7 +97,8 @@ int handle_auth(ssh_session session) {
 
         /* Log the authentication request and disconnect. */
         if (ssh_message_subtype(con.message) == SSH_AUTH_METHOD_PASSWORD) {
-                log_attempt(&con);
+                log_attempt(&con, logfile, syslog_bool);
+		sleep(delay); 
         }
         else {
             if (DEBUG) { fprintf(stderr, "Not a password authentication attempt.\n"); }
@@ -99,3 +112,44 @@ int handle_auth(ssh_session session) {
     if (DEBUG) { printf("Exiting child.\n"); }
     return 0;
 }
+
+
+void drop_priv (char *user, char *group) { 
+
+
+   struct passwd *pw = NULL;
+
+   pw = getpwnam(user);
+
+   if (!pw) { 
+	fprintf(stderr, "Cannot locate user: '%s'. Abort!\n", user); 
+	exit(-1); 
+	}
+   
+   if ( getuid() == 0 ) { 
+
+	printf("Dropping priv to %s:%s.\n", user, group); 
+
+	if (initgroups(pw->pw_name, pw->pw_gid) != 0 || setgid(pw->pw_gid) != 0 || setuid(pw->pw_uid) != 0) { 
+		fprintf(stderr, "Could not drop privs! Abort!\n"); 
+		exit(-1); 
+		}
+
+	} else { 
+	
+	printf("Not dropping priv.  Already a unprivledged user.\n"); 
+	}
+
+}
+
+void sshpot_chroot (const char *chrootdir) { 
+
+    printf("Chroot to %s.\n", chrootdir); 
+
+    if (chroot(chrootdir) != 0 || chdir ("/") != 0)  { 
+	fprintf(stderr, "Cannot chroot to %s", chrootdir); 
+	exit(-1); 
+	}
+
+}
+

--- a/auth.h
+++ b/auth.h
@@ -1,6 +1,7 @@
 #ifndef AUTH_H
 #define AUTH_H
 
+#include <stdbool.h>
 #include <libssh/libssh.h>
 
 #define MAXBUF 100
@@ -14,6 +15,8 @@ struct connection {
     char *pass;
 };
 
-int handle_auth(ssh_session session);
+int handle_auth(ssh_session session, char *logfile, bool syslog, int delay);
+void drop_priv(char *user, char *group); 
+void sshpot_chroot (const char *chrootdir);
 
 #endif

--- a/config.h
+++ b/config.h
@@ -12,6 +12,10 @@
 #define	USER		"nobody"
 #define GROUP		"nogroup"
 
+/* the "SSH-2.0-" is automatically added by libssh! */
+
+#define BANNER		"OpenSSH_6.7p1 Debian-5+deb8u3"
+
 #define DELAY		2
 
 #define SYSLOG_FACILITY	LOG_AUTH

--- a/config.h
+++ b/config.h
@@ -1,10 +1,20 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <syslog.h>
+
 #define LISTENADDRESS   "0.0.0.0"
 #define DEFAULTPORT     22
 #define RSA_KEYFILE     "./sshpot.rsa.key"
 #define LOGFILE         "sshpot_auth.log"
-#define DEBUG           0
+#define DEBUG		0
+
+#define	USER		"nobody"
+#define GROUP		"nogroup"
+
+#define DELAY		2
+
+#define SYSLOG_FACILITY	LOG_AUTH
+#define SYSLOG_PRIORITY LOG_ALERT
 
 #endif

--- a/main.c
+++ b/main.c
@@ -35,7 +35,10 @@ static void usage(FILE *stream, int exit_code) {
 	    "   -g  --group <group>    Group to drop privs to; defaults to '%s'.\n"
 	    "   -d  --daemon           Become a daemon.\n"
 	    "   -t  --delay <#>        Seconds to delay between auth attempts; default %ds.\n"
-	    "   -c  --chroot <dir>     Run in a chroot environment.\n", LISTENADDRESS, DEFAULTPORT, RSA_KEYFILE, LOGFILE, USER, GROUP, DELAY ); 
+	    "   -c  --chroot <dir>     Run in a chroot environment.\n"
+	    "   -b  --banner <banner>  SSH Banner; defaults to '%s'.\n", LISTENADDRESS, DEFAULTPORT, RSA_KEYFILE, LOGFILE, USER, GROUP, DELAY, BANNER ); 
+
+
     exit(exit_code);
 }
 
@@ -92,9 +95,9 @@ int main(int argc, char *argv[]) {
     char *user = USER; 
     char *group = GROUP; 
     char *listen = LISTENADDRESS; 
+    char *banner = BANNER; 
 
     char *chroot = NULL; 
-
 
     bool syslog_bool = 0; 
     bool chroot_bool = 0; 
@@ -102,7 +105,7 @@ int main(int argc, char *argv[]) {
 
     /* Handle command line options. */
     int next_opt = 0;
-    const char *short_opts = "c:g:u:l:L:r:p:hsd";
+    const char *short_opts = "b:c:g:u:l:L:r:p:hsd";
     const struct option long_opts[] = {
         { "help",    no_argument, NULL, 'h' },
 	{ "daemon",  no_argument, NULL, 'd' }, 
@@ -115,6 +118,7 @@ int main(int argc, char *argv[]) {
 	{ "delay",   required_argument, NULL, 't' }, 
 	{ "chroot",  required_argument, NULL, 'c' }, 
 	{ "listen",  required_argument, NULL, 'l' }, 
+        { "banner",  required_argument, NULL, 'b' }, 
         { NULL,      0, NULL, 0   }
     };
 
@@ -155,6 +159,10 @@ int main(int argc, char *argv[]) {
 	    case 'g':
 		group = optarg; 
 		break; 
+
+	    case 'b': 
+		banner = optarg; 
+		break;
 
 	    case 'd': 
 		daemon_bool = 1; 
@@ -199,6 +207,8 @@ int main(int argc, char *argv[]) {
     ssh_bind_options_set(sshbind, SSH_BIND_OPTIONS_BINDPORT, &port);
     ssh_bind_options_set(sshbind, SSH_BIND_OPTIONS_HOSTKEY, "ssh-rsa");
     ssh_bind_options_set(sshbind, SSH_BIND_OPTIONS_RSAKEY,rsa_keyfile);
+    ssh_bind_options_set(sshbind, SSH_BIND_OPTIONS_BANNER, banner);
+
 
     /* Listen on `port' for connections. */
     if (ssh_bind_listen(sshbind) < 0) {


### PR DESCRIPTION
This is a really nice,  simple utility.  I've extended it a good bit to fit what I need and wanted to share it.  Here's what this pull includes: 

1. Command line option so user can pick where to listen (defaults to 0.0.0.0)
2. Added --rsa command line RSA key file support.  
3. Added --logfile support. 
4. Added --user/--group.  SSHPot now "drops privs" after binding.  Defaults to user "nobody" and "nogroup". 
5. Added --daemon.  Now forks to a background processes. 
6. Added --delay.  Let's you added a delay between auth's to make it seem more realistic.  Defaults to 2 seconds.
7. --chroot - Process can chroot to a command line directory.
8. --banner - Allows you to set the SSH banner.  Defaults to "OpenSSH_6.7p1 Debian-5+deb8u3"

Couple of things.  Can you please specify the licensing on your software?  Please let me know if you have any questions! Thanks